### PR TITLE
Polish About & Contemplation UI and replace deprecated settings radios

### DIFF
--- a/lib/ui/screens/about_screen.dart
+++ b/lib/ui/screens/about_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -19,6 +21,9 @@ class _AboutScreenState extends State<AboutScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Scaffold(
       appBar: AppBar(
         title: Text(
@@ -27,273 +32,290 @@ class _AboutScreenState extends State<AboutScreen> {
         ),
         centerTitle: true,
       ),
-      body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: [
-              Color(0xFFF7FBFD),
-              Color(0xFFF1F6FA),
-            ],
+      body: Stack(
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  if (isDark)
+                    const Color(0xFF09121D)
+                  else
+                    const Color(0xFFF8FCFF),
+                  if (isDark)
+                    const Color(0xFF0F1C2B)
+                  else
+                    const Color(0xFFEDF7FD),
+                ],
+              ),
+            ),
           ),
-        ),
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            children: [
-              // App Icon
-              Container(
-                width: 120,
-                height: 120,
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      AppColors.primary,
-                      AppColors.primaryLight,
+          Positioned(
+            top: -120,
+            right: -70,
+            child: _BackgroundGlow(
+              size: 280,
+              color: scheme.primary.withValues(alpha: isDark ? 0.25 : 0.16),
+            ),
+          ),
+          Positioned(
+            bottom: -160,
+            left: -90,
+            child: _BackgroundGlow(
+              size: 300,
+              color: scheme.secondary.withValues(alpha: isDark ? 0.22 : 0.14),
+            ),
+          ),
+          SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              children: [
+                Container(
+                  width: 132,
+                  height: 132,
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        scheme.primary,
+                        scheme.secondary,
+                      ],
+                    ),
+                    borderRadius: BorderRadius.circular(36),
+                    border: Border.all(
+                      color: AppColors.white.withValues(alpha: 0.28),
+                    ),
+                    boxShadow: [
+                      BoxShadow(
+                        color: scheme.primary.withValues(alpha: 0.32),
+                        blurRadius: 36,
+                        offset: const Offset(0, 14),
+                      ),
                     ],
                   ),
-                  borderRadius: BorderRadius.circular(28),
-                  boxShadow: [
-                    BoxShadow(
-                      color: AppColors.primary.withValues(alpha: 0.3),
-                      blurRadius: 30,
-                      offset: const Offset(0, 10),
+                  child: const Icon(
+                    Icons.auto_stories_rounded,
+                    size: 68,
+                    color: AppColors.white,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Directionality(
+                  textDirection: TextDirection.rtl,
+                  child: Text(
+                    'حكمة',
+                    style: GoogleFonts.notoNaskhArabic(
+                      fontSize: 44,
+                      fontWeight: FontWeight.w700,
+                      color: scheme.onSurface,
+                      height: 1.2,
                     ),
-                  ],
+                    textAlign: TextAlign.center,
+                  ),
                 ),
-                child: const Icon(
-                  Icons.auto_stories_rounded,
-                  size: 64,
-                  color: AppColors.white,
-                ),
-              ),
-              const SizedBox(height: 24),
-
-              // App Name in Arabic
-              Directionality(
-                textDirection: TextDirection.rtl,
-                child: Text(
-                  'حكمة',
-                  style: GoogleFonts.notoNaskhArabic(
-                    fontSize: 42,
+                const SizedBox(height: 6),
+                Text(
+                  'Hikma',
+                  style: GoogleFonts.cormorantGaramond(
+                    fontSize: 48,
                     fontWeight: FontWeight.w700,
-                    color: AppColors.text,
-                    height: 1.2,
+                    color: scheme.onSurface,
+                    letterSpacing: 1.4,
                   ),
                   textAlign: TextAlign.center,
                 ),
-              ),
-              const SizedBox(height: 8),
-
-              // App Name in English
-              Text(
-                'Hikma',
-                style: GoogleFonts.tajawal(
-                  fontSize: 36,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.primaryDark,
-                  letterSpacing: 2,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 12),
-
-              // Tagline
-              Text(
-                'Wisdom from the Prophetic Traditions',
-                style: GoogleFonts.tajawal(
-                  fontSize: 14,
-                  color: AppColors.textMuted,
-                  fontWeight: FontWeight.w500,
-                ),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 8),
-
-              // Version
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 6,
-                ),
-                decoration: BoxDecoration(
-                  color: AppColors.primary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(20),
-                  border: Border.all(
-                    color: AppColors.primary.withValues(alpha: 0.2),
-                    width: 1,
-                  ),
-                ),
-                child: Text(
-                  'Version $version (Build $buildNumber)',
+                const SizedBox(height: 8),
+                Text(
+                  'Wisdom from the Prophetic Traditions',
                   style: GoogleFonts.tajawal(
-                    fontSize: 12,
-                    color: AppColors.primary,
-                    fontWeight: FontWeight.w700,
+                    fontSize: 14,
+                    color: scheme.onSurface.withValues(alpha: 0.68),
+                    fontWeight: FontWeight.w500,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 14,
+                    vertical: 7,
+                  ),
+                  decoration: BoxDecoration(
+                    color: scheme.primary.withValues(alpha: 0.12),
+                    borderRadius: BorderRadius.circular(20),
+                    border: Border.all(
+                      color: scheme.primary.withValues(alpha: 0.28),
+                      width: 1,
+                    ),
+                  ),
+                  child: Text(
+                    'Version $version (Build $buildNumber)',
+                    style: GoogleFonts.tajawal(
+                      fontSize: 12,
+                      color: scheme.primary,
+                      fontWeight: FontWeight.w700,
+                    ),
                   ),
                 ),
-              ),
-              const SizedBox(height: 32),
-
-              // Description Card
-              const _InfoSection(
-                title: 'About Hikma',
-                icon: Icons.info_outline,
-                content: 'Hikma brings authentic Hadith from the six canonical '
-                    'collections (Kutub al-Sittah) directly to your desktop. '
-                    'Receive beautiful, non-intrusive notifications throughout '
-                    'your day to reflect upon the wisdom of the Prophet '
-                    'Muhammad (peace be upon him).',
-              ),
-
-              const SizedBox(height: 16),
-
-              // Collections Section
-              _InfoSection(
-                title: 'Hadith Collections',
-                icon: Icons.menu_book,
-                child: const Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _CollectionItem(
-                      englishName: 'Sahih Al-Bukhari',
-                      arabicName: 'صحيح البخاري',
-                    ),
-                    _CollectionItem(
-                      englishName: 'Sahih Muslim',
-                      arabicName: 'صحيح مسلم',
-                    ),
-                    _CollectionItem(
-                      englishName: 'Sunan Abu Dawud',
-                      arabicName: 'سنن أبي داود',
-                    ),
-                    _CollectionItem(
-                      englishName: "Jami' Al-Tirmidhi",
-                      arabicName: 'جامع الترمذي',
-                    ),
-                    _CollectionItem(
-                      englishName: 'Sunan Ibn Majah',
-                      arabicName: 'سنن ابن ماجه',
-                    ),
-                    _CollectionItem(
-                      englishName: 'Sunan Al-Nasa\'i',
-                      arabicName: 'سنن النسائي',
-                    ),
-                  ],
+                const SizedBox(height: 28),
+                const _InfoSection(
+                  title: 'About Hikma',
+                  icon: Icons.info_outline,
+                  content:
+                      'Hikma brings authentic Hadith from the six canonical '
+                      'collections (Kutub al-Sittah) directly to your desktop. '
+                      'Receive beautiful, non-intrusive notifications throughout '
+                      'your day to reflect upon the wisdom of the Prophet '
+                      'Muhammad (peace be upon him).',
                 ),
-              ),
-
-              const SizedBox(height: 16),
-
-              // Features Section
-              const _InfoSection(
-                title: 'Features',
-                icon: Icons.star_outline,
-                content: '• Random Hadith notifications\n'
-                    '• Customizable reminder intervals\n'
-                    '• Save and organize favorite Hadiths\n'
-                    '• Beautiful frosted glass interface\n'
-                    '• Offline caching for accessibility\n'
-                    '• Multiple font size options\n'
-                    '• Adjustable popup duration',
-              ),
-
-              const SizedBox(height: 16),
-
-              // Tech Stack Section
-              _InfoSection(
-                title: 'Built With',
-                icon: Icons.code,
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: [
-                    _TechChip(label: 'Flutter', icon: Icons.flutter_dash),
-                    _TechChip(label: 'Dart', icon: Icons.code),
-                    _TechChip(label: 'BLoC', icon: Icons.extension),
-                    _TechChip(label: 'Hive', icon: Icons.storage),
-                    _TechChip(label: 'Acrylic', icon: Icons.blur_on),
-                  ],
-                ),
-              ),
-
-              const SizedBox(height: 32),
-
-              // Attribution
-              Card(
-                elevation: 0,
-                color: AppColors.surfaceElevated,
-                child: Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: Column(
+                const SizedBox(height: 16),
+                _InfoSection(
+                  title: 'Hadith Collections',
+                  icon: Icons.menu_book,
+                  child: const Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      const Icon(
-                        Icons.favorite,
-                        size: 16,
-                        color: AppColors.favorite,
+                      _CollectionItem(
+                        englishName: 'Sahih Al-Bukhari',
+                        arabicName: 'صحيح البخاري',
                       ),
-                      const SizedBox(height: 8),
-                      Text(
-                        'Made with love for the Muslim Ummah',
-                        style: GoogleFonts.tajawal(
-                          fontSize: 13,
-                          color: AppColors.textMuted,
-                          fontWeight: FontWeight.w600,
-                        ),
+                      _CollectionItem(
+                        englishName: 'Sahih Muslim',
+                        arabicName: 'صحيح مسلم',
                       ),
-                      const SizedBox(height: 4),
-                      Text(
-                        'Data sourced from Sunnah.com API',
-                        style: GoogleFonts.tajawal(
-                          fontSize: 11,
-                          color: AppColors.text.withValues(alpha: 0.5),
-                          fontWeight: FontWeight.w500,
-                        ),
+                      _CollectionItem(
+                        englishName: 'Sunan Abu Dawud',
+                        arabicName: 'سنن أبي داود',
+                      ),
+                      _CollectionItem(
+                        englishName: "Jami' Al-Tirmidhi",
+                        arabicName: 'جامع الترمذي',
+                      ),
+                      _CollectionItem(
+                        englishName: 'Sunan Ibn Majah',
+                        arabicName: 'سنن ابن ماجه',
+                      ),
+                      _CollectionItem(
+                        englishName: 'Sunan Al-Nasa\'i',
+                        arabicName: 'سنن النسائي',
                       ),
                     ],
                   ),
                 ),
-              ),
-
-              const SizedBox(height: 24),
-
-              // Copyright
-              Text(
-                '© 2025 Hikma. All rights reserved.',
-                style: GoogleFonts.tajawal(
-                  fontSize: 11,
-                  color: AppColors.text.withValues(alpha: 0.4),
-                  fontWeight: FontWeight.w500,
+                const SizedBox(height: 16),
+                const _InfoSection(
+                  title: 'Features',
+                  icon: Icons.star_outline,
+                  content: '• Random Hadith notifications\n'
+                      '• Customizable reminder intervals\n'
+                      '• Save and organize favorite Hadiths\n'
+                      '• Beautiful frosted glass interface\n'
+                      '• Offline caching for accessibility\n'
+                      '• Multiple font size options\n'
+                      '• Adjustable popup duration',
                 ),
-              ),
-
-              // Copy version button
-              const SizedBox(height: 16),
-              TextButton.icon(
-                onPressed: () {
-                  Clipboard.setData(
-                    const ClipboardData(
-                        text: 'Hikma v$version (Build $buildNumber)'),
-                  );
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Version info copied to clipboard'),
-                      duration: Duration(seconds: 2),
+                const SizedBox(height: 16),
+                _InfoSection(
+                  title: 'Built With',
+                  icon: Icons.code,
+                  child: Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _TechChip(label: 'Flutter', icon: Icons.flutter_dash),
+                      _TechChip(label: 'Dart', icon: Icons.code),
+                      _TechChip(label: 'BLoC', icon: Icons.extension),
+                      _TechChip(label: 'Hive', icon: Icons.storage),
+                      _TechChip(label: 'Acrylic', icon: Icons.blur_on),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 28),
+                Card(
+                  elevation: 0,
+                  color: Colors.transparent,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    child: BackdropFilter(
+                      filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+                      child: Container(
+                        padding: const EdgeInsets.all(16.0),
+                        decoration: BoxDecoration(
+                          color: scheme.surface
+                              .withValues(alpha: isDark ? 0.68 : 0.78),
+                          border: Border.all(
+                            color: scheme.onSurface
+                                .withValues(alpha: isDark ? 0.16 : 0.1),
+                          ),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Column(
+                          children: [
+                            const Icon(
+                              Icons.favorite,
+                              size: 16,
+                              color: AppColors.favorite,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              'Made with love for the Muslim Ummah',
+                              style: GoogleFonts.tajawal(
+                                fontSize: 13,
+                                color: scheme.onSurface.withValues(alpha: 0.72),
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Data sourced from Sunnah.com API',
+                              style: GoogleFonts.tajawal(
+                                fontSize: 11,
+                                color: scheme.onSurface.withValues(alpha: 0.56),
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                     ),
-                  );
-                },
-                icon: const Icon(Icons.copy, size: 16),
-                label: const Text('Copy Version Info'),
-                style: TextButton.styleFrom(
-                  foregroundColor: AppColors.primary,
+                  ),
                 ),
-              ),
-            ],
+                const SizedBox(height: 22),
+                Text(
+                  '© 2025 Hikma. All rights reserved.',
+                  style: GoogleFonts.tajawal(
+                    fontSize: 11,
+                    color: scheme.onSurface.withValues(alpha: 0.46),
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextButton.icon(
+                  onPressed: () {
+                    Clipboard.setData(
+                      const ClipboardData(
+                          text: 'Hikma v$version (Build $buildNumber)'),
+                    );
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Version info copied to clipboard'),
+                        duration: Duration(seconds: 2),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.copy, size: 16),
+                  label: const Text('Copy Version Info'),
+                  style: TextButton.styleFrom(
+                    foregroundColor: scheme.primary,
+                  ),
+                ),
+              ],
+            ),
           ),
-        ),
+        ],
       ),
     );
   }
@@ -315,51 +337,96 @@ class _InfoSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
     return Card(
-      elevation: 1,
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+      elevation: 0,
+      color: Colors.transparent,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(22),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+          child: Container(
+            padding: const EdgeInsets.all(16.0),
+            decoration: BoxDecoration(
+              color: scheme.surface.withValues(alpha: isDark ? 0.7 : 0.82),
+              border: Border.all(
+                color: scheme.onSurface.withValues(alpha: isDark ? 0.16 : 0.1),
+              ),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Container(
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: AppColors.primary.withValues(alpha: 0.1),
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: Icon(
-                    icon,
-                    size: 20,
-                    color: AppColors.primary,
-                  ),
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(8),
+                      decoration: BoxDecoration(
+                        color: scheme.primary.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Icon(
+                        icon,
+                        size: 20,
+                        color: scheme.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Text(
+                      title,
+                      style: GoogleFonts.tajawal(
+                        fontSize: 18,
+                        fontWeight: FontWeight.w700,
+                        color: scheme.onSurface,
+                      ),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 12),
-                Text(
-                  title,
-                  style: GoogleFonts.tajawal(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.primaryDark,
+                const SizedBox(height: 12),
+                if (content != null)
+                  Text(
+                    content!,
+                    style: GoogleFonts.tajawal(
+                      fontSize: 14,
+                      height: 1.6,
+                      color: scheme.onSurface.withValues(alpha: 0.72),
+                      fontWeight: FontWeight.w500,
+                    ),
                   ),
-                ),
+                if (child != null) child!,
               ],
             ),
-            const SizedBox(height: 12),
-            if (content != null)
-              Text(
-                content!,
-                style: GoogleFonts.tajawal(
-                  fontSize: 14,
-                  height: 1.6,
-                  color: AppColors.textMuted,
-                  fontWeight: FontWeight.w500,
-                ),
-              ),
-            if (child != null) child!,
-          ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BackgroundGlow extends StatelessWidget {
+  final double size;
+  final Color color;
+
+  const _BackgroundGlow({
+    required this.size,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: Container(
+        width: size,
+        height: size,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          gradient: RadialGradient(
+            colors: [
+              color,
+              color.withValues(alpha: 0.02),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screens/contemplation_screen.dart
+++ b/lib/ui/screens/contemplation_screen.dart
@@ -116,9 +116,9 @@ class _ContemplationScreenState extends State<ContemplationScreen>
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  AppColors.primaryDark,
-                  AppColors.primary,
-                  const Color(0xFF0C2B42),
+                  const Color(0xFF071423),
+                  const Color(0xFF0B2C46),
+                  const Color(0xFF0E3A5A),
                 ],
               ),
             ),
@@ -179,7 +179,7 @@ class _ContemplationScreenState extends State<ContemplationScreen>
                                             ),
                                             decoration: BoxDecoration(
                                               color: AppColors.white
-                                                  .withValues(alpha: 0.1),
+                                                  .withValues(alpha: 0.12),
                                               borderRadius:
                                                   BorderRadius.circular(28),
                                               border: Border.all(
@@ -196,8 +196,8 @@ class _ContemplationScreenState extends State<ContemplationScreen>
                                                     _currentHadith!.arabicText,
                                                     style: GoogleFonts
                                                         .notoNaskhArabic(
-                                                      fontSize: 33,
-                                                      height: 2.25,
+                                                      fontSize: 35,
+                                                      height: 2.2,
                                                       color: AppColors.white,
                                                       fontWeight:
                                                           FontWeight.w500,
@@ -292,9 +292,9 @@ class _ContemplationScreenState extends State<ContemplationScreen>
                 Text(
                   'Contemplation Mode',
                   style: GoogleFonts.tajawal(
-                    fontSize: 14,
+                    fontSize: 15,
                     color: AppColors.white.withValues(alpha: 0.86),
-                    fontWeight: FontWeight.w600,
+                    fontWeight: FontWeight.w700,
                   ),
                 ),
                 const SizedBox(width: 48),
@@ -349,11 +349,18 @@ class _ActionButton extends StatelessWidget {
         child: Ink(
           padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
           decoration: BoxDecoration(
-            color: AppColors.white.withValues(alpha: 0.16),
+            color: AppColors.white.withValues(alpha: 0.14),
             borderRadius: BorderRadius.circular(28),
             border: Border.all(
-              color: AppColors.white.withValues(alpha: 0.24),
+              color: AppColors.white.withValues(alpha: 0.28),
             ),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.black.withValues(alpha: 0.16),
+                blurRadius: 16,
+                offset: const Offset(0, 8),
+              ),
+            ],
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -453,26 +453,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const Divider(),
               ...HadithCollection.values.map((collection) {
-                return RadioListTile<HadithCollection>(
-                  title: Text(collection.displayName),
-                  subtitle: Text(collection.arabicName),
-                  value: collection,
-                  groupValue: current,
-                  onChanged: (value) {
-                    if (value != null) {
-                      context.read<SettingsBloc>().add(
-                            UpdateSourceCollection(value),
-                          );
-                      Navigator.of(context).pop();
-                    }
-                  },
+                return _buildSelectionTile(
+                  title: collection.displayName,
+                  subtitle: collection.arabicName,
                   selected: collection == current,
-                  fillColor: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.selected)) {
-                      return AppColors.primary;
-                    }
-                    return null;
-                  }),
+                  onTap: () {
+                    context.read<SettingsBloc>().add(
+                          UpdateSourceCollection(collection),
+                        );
+                    Navigator.of(context).pop();
+                  },
                 );
               }),
             ],
@@ -505,25 +495,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const Divider(),
               ...ReminderInterval.values.map((interval) {
-                return RadioListTile<ReminderInterval>(
-                  title: Text(interval.displayLabel),
-                  value: interval,
-                  groupValue: current,
-                  onChanged: (value) {
-                    if (value != null) {
-                      context.read<SettingsBloc>().add(
-                            UpdateReminderInterval(value),
-                          );
-                      Navigator.of(context).pop();
-                    }
-                  },
+                return _buildSelectionTile(
+                  title: interval.displayLabel,
                   selected: interval == current,
-                  fillColor: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.selected)) {
-                      return AppColors.primary;
-                    }
-                    return null;
-                  }),
+                  onTap: () {
+                    context.read<SettingsBloc>().add(
+                          UpdateReminderInterval(interval),
+                        );
+                    Navigator.of(context).pop();
+                  },
                 );
               }),
             ],
@@ -556,34 +536,62 @@ class _SettingsScreenState extends State<SettingsScreen> {
               ),
               const Divider(),
               ...PopupDuration.values.map((duration) {
-                return RadioListTile<PopupDuration>(
-                  title: Text(duration.displayLabel),
+                return _buildSelectionTile(
+                  title: duration.displayLabel,
                   subtitle: duration == PopupDuration.manual
-                      ? const Text('Popup stays visible until dismissed')
+                      ? 'Popup stays visible until dismissed'
                       : null,
-                  value: duration,
-                  groupValue: current,
-                  onChanged: (value) {
-                    if (value != null) {
-                      context.read<SettingsBloc>().add(
-                            UpdatePopupDuration(value),
-                          );
-                      Navigator.of(context).pop();
-                    }
-                  },
                   selected: duration == current,
-                  fillColor: WidgetStateProperty.resolveWith((states) {
-                    if (states.contains(WidgetState.selected)) {
-                      return AppColors.primary;
-                    }
-                    return null;
-                  }),
+                  onTap: () {
+                    context.read<SettingsBloc>().add(
+                          UpdatePopupDuration(duration),
+                        );
+                    Navigator.of(context).pop();
+                  },
                 );
               }),
             ],
           ),
         );
       },
+    );
+  }
+
+  Widget _buildSelectionTile({
+    required String title,
+    String? subtitle,
+    required bool selected,
+    required VoidCallback onTap,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return ListTile(
+      onTap: onTap,
+      title: Text(title),
+      subtitle: subtitle == null ? null : Text(subtitle),
+      trailing: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          shape: BoxShape.circle,
+          color: selected
+              ? colorScheme.primary.withValues(alpha: 0.18)
+              : Colors.transparent,
+          border: Border.all(
+            color: selected
+                ? colorScheme.primary
+                : colorScheme.onSurface.withValues(alpha: 0.35),
+            width: 1.5,
+          ),
+        ),
+        child: selected
+            ? Icon(
+                Icons.check_rounded,
+                size: 14,
+                color: colorScheme.primary,
+              )
+            : null,
+      ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   equatable: ^2.0.5
 
   # Local Storage
+  hive: ^2.2.3
   hive_flutter: ^1.1.0
 
   # HTTP Client


### PR DESCRIPTION
## Summary
- Redesigned About screen with liquid-glass visual treatment and better typography hierarchy.
- Refined Contemplation screen styling for consistency with the 2027 visual identity direction.
- Replaced deprecated RadioListTile usage in Settings pickers with modern custom selection rows.
- Added direct hive dependency because it is imported directly in repositories/tests.

## Validation
- flutter analyze --fatal-warnings --no-fatal-infos
- flutter test
- flutter build macos --debug
- macOS app launch smoke test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme-aware gradients and decorative visual elements on the About screen
  * New branding display with Arabic and English titles
  * Added "Built With" technology section
  * Redesigned selection indicators in settings menu

* **Style**
  * Enhanced typography and font sizing across screens
  * Improved button styling with shadows and refined opacity
  * Better color consistency for dark and light themes
  * Updated visual polish on UI components

* **Chores**
  * Added local storage dependency for enhanced data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->